### PR TITLE
ansible: fix collections_paths deprecation

### DIFF
--- a/plays/ansible.cfg
+++ b/plays/ansible.cfg
@@ -5,7 +5,7 @@
 
 inventory = ../hosts
 roles_path = ../roles
-collections_paths = ../collections
+collections_path = ../collections
 
 transport = ssh
 interpreter_python = python3


### PR DESCRIPTION
```
Aug 29 20:07:04 svc-adm01 ddix-ixp-deploy[44076]: [DEPRECATION WARNING]: [defaults]collections_paths option. Reason: does not fit
Aug 29 20:07:04 svc-adm01 ddix-ixp-deploy[44076]:  var naming standard, use the singular form collections_path instead
```